### PR TITLE
feat: use the archive_file resource - Chef 15+

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,18 +16,18 @@ platforms:
     driver:
       image: dokken/centos-7
       privileged: true
-      pid_one_command: /usr/lib/systemd/systemd
+      pid_one_command: /usr/lib/systemd/systemd --system
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
   - name: debian
     driver:
-      image: dokken/debian-10
+      image: dokken/debian-12
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
   - name: ubuntu
     driver:
-      image: dokken/ubuntu-20.04
+      image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/Berksfile
+++ b/Berksfile
@@ -3,7 +3,7 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
-  cookbook 'consul', '~> 3.1.0'
+  cookbook 'consul', '~> 5.0.0'
   cookbook 'selinux', '~> 2.1.1'
   cookbook 'test', path: 'test/cookbooks/test'
 end

--- a/README.md
+++ b/README.md
@@ -7,43 +7,44 @@ Installs and configures [consul-template](https://github.com/hashicorp/consul-te
 
 This is a fork of https://github.com/adamkrone/chef-consul-template with the following changes:
 
- - Drop support for Windows
- - No longer use libarchive as it causes a lot of problems.
- - Use the tgz packages instead of the zip ones.
- - Use a more modern style of defining resources.
- - Collapse all the recipes into default.
- - Only define the checksums for the 0.24.1, 0.23.0, and 0.22.1. Or in other words, just for the latest 3 minor versions.
- - Support the arm architecture.
- - Only support the linux OS.
- 
+* Drop support for Windows
+* No longer use libarchive as it causes a lot of problems.
+* Use the tgz packages instead of the zip ones.
+* Use a more modern style of defining resources.
+* Collapse all the recipes into default.
+* Only define the checksums for the latest 3 minor versions.
+* Support the arm architecture.
+* Only support the linux OS.
+
 ## Supported Platforms
 
-- Ubuntu 18.04
-- Debian 9.8
-- Centos 7.6
+* Ubuntu 20.04
+* Debian 12.8
+* Centos 7.9
 
 ## Attributes
 
-- `node['consul_template']['base_url']` - Base URL for consul-template binary files
-- `node['consul_template']['version']` - Version of consul-template to install.
+* `node['consul_template']['base_url']` - Base URL for consul-template binary files
+* `node['consul_template']['version']` - Version of consul-template to install.
   Used to determine which binary to grab from the base_url.
-- `'node['consul_template']['install_dir']` - Directory where consul-template
+* `'node['consul_template']['install_dir']` - Directory where consul-template
   should be installed.
-- `node['consul_template']['checksums']` - Contains a hash of checksums where
+* `node['consul_template']['checksums']` - Contains a hash of checksums where
   the key is the file for a given OS/architecture, and the value is the
   associated checksum. For example, `consul-template_0.3.1_linux_amd64`.
-- `node['consul_template']['config_dir']` - The directory that contains the
+* `node['consul_template']['config_dir']` - The directory that contains the
   configuration files for consul-template.
-- `node['consul_template']['service_user']` - Defines the user that should be
+* `node['consul_template']['service_user']` - Defines the user that should be
   used for the consul-template service.
-- `node['consul_template']['service_group']` - Defines the group that should be
+* `node['consul_template']['service_group']` - Defines the group that should be
   used for the consul-template service.
-- `node['consul_template']['template_mode']` - File permissions mode for all
+* `node['consul_template']['template_mode']` - File permissions mode for all
   consul-template configuration files.
-- `node['consul_template']['consul_addr']` - Name:port to access consul (default: `127.0.0.1:8500`)
-- `node['consul_template']['vault_addr']` - URL to access Vault (default: `https://127.0.0.1:8200`)
+* `node['consul_template']['consul_addr']` - Name:port to access consul (default: `127.0.0.1:8500`)
+* `node['consul_template']['vault_addr']` - URL to access Vault (default: `https://127.0.0.1:8200`)
 
 Additionally, the contents of the `node['consul_template']['config']` hash will be reflected into the default configuration file -- `/etc/consul-template.d/default.json`.
+
 ## Recipes
 
 ### default
@@ -70,4 +71,3 @@ consul_template_config 'haproxy' do
   notifies :reload, 'service[consul-template]', :delayed
 end
 ```
-

--- a/attributes/checksums.rb
+++ b/attributes/checksums.rb
@@ -1,4 +1,19 @@
 default['consul_template']['checksums'] = {
+  'consul-template_0.29.0_linux_386' => 'e8812e977da1da2b2e67fb04e959d0f4a251e3b18d1f25f77e5593058b38c19c',
+  'consul-template_0.29.0_linux_amd64' => '9178437bde1f0f220010f17806c01b36ccb3814f065d4ebdfba53ade9832012d',
+  'consul-template_0.29.0_linux_arm' => 'f46755c708950baf57ff76203f302344bdcac97c7ebb13ed01fab1a753fca45e',
+  'consul-template_0.29.0_linux_arm64' => '6bbb36d9a47be9f739452147dc4b042bbebdb8fbbaf9a432f1e2a5454478150b',
+
+  'consul-template_0.28.1_linux_386' => 'bf5a607b74fab031a7727a80ac34239a94cc508f0f7517a681e98e847054fbca',
+  'consul-template_0.28.1_linux_amd64' => '3afe87115cf1b77196c7a4daab6429e495cd307c49deab255ff2adf2b3923541',
+  'consul-template_0.28.1_linux_arm' => '9ac419f80c6bfad29720aa11227be6908ebc06367547fbc853d6c2fc680ebaf7',
+  'consul-template_0.28.1_linux_arm64' => 'a29aae902d74f930f3a3b4837e0603d29a8991b57ed9f04b21a91cffc92dec22',
+
+  'consul-template_0.27.2_linux_386' => '31ad36a7663fef454ceecfe67d7b33ed830932d329d38b7e0eb2ff8d51757d92',
+  'consul-template_0.27.2_linux_amd64' => 'd3d428ede8cb6e486d74b74deb9a7cdba6a6de293f3311f178cc147f1d1837e8',
+  'consul-template_0.27.2_linux_arm' => 'b453170ba4c35176bfab3bba6b81f7d9ca58425b1bb9bdf342428240d1af59ac',
+  'consul-template_0.27.2_linux_arm64' => '4ea1ac760a4deee9c1297c8c2e57f5a98dd4ecdf75d6e26b1f1105918b23f195',
+
   'consul-template_0.25.1_linux_386' => 'dd6344018331e4c1b68cdd0192f9161e9fb5b35d5239e2b35b737003753d8a41',
   'consul-template_0.25.1_linux_amd64' => '80b8068a155ff99808a3f7feafb16b2db7c40c0e1d034153f98cc3d79972d10b',
   'consul-template_0.25.1_linux_arm' => '792b18276cb8b62f127b6e616b8c946695d1fde85476f0077a806f1f11e99e02',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,7 @@ default['consul_template'] = {
   'service_user' => 'consul-template',
   'service_group' => 'consul-template',
   'service_execstartpre' => "",
+  'service_timeoutstartsec' => nil,
   'template_mode' => 0600,
 
   # Config attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['consul_template'] = {
   'base_url' => 'https://releases.hashicorp.com/consul-template/',
-  'version' => '0.25.1',
+  'version' => '0.29.0',
   'install_dir' => '/usr/local/bin',
 
   # Service attributes
@@ -14,6 +14,7 @@ default['consul_template'] = {
   'create_service_user' => true,
   'service_user' => 'consul-template',
   'service_group' => 'consul-template',
+  'service_execstartpre' => "",
   'template_mode' => 0600,
 
   # Config attributes

--- a/generate-checksums
+++ b/generate-checksums
@@ -14,11 +14,12 @@ version=$1
 empty_sha=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 systems=(linux_386 linux_amd64 linux_arm linux_arm64)
 files=()
+suffix="zip"
 
 function get_files {
   for system in "${systems[@]}"
   do
-    file=("consul-template_${version}_${system}.tgz")
+    file=("consul-template_${version}_${system}.${suffix}")
     files+=(${file})
   done
 }
@@ -33,7 +34,7 @@ function print_checksums {
     if [ "$checksum" = "$empty_sha" ]; then
       >&2 echo "Failed to get binary: $binary"
     else
-      echo "'${file//.tgz}' => '$checksum',"
+      echo "'${file//.${suffix}}' => '$checksum',"
     fi
   done
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,11 +5,9 @@ maintainer       'Simão Martins'
 maintainer_email 'simao.martins@tecnico.ulisboa.pt'
 license          'Apache-2.0'
 description      'Installs/Configures consul-template. This is a fork of the consul-template cookbook which fixes some errors and removes support for Windows.'
-version          '1.0.0'
-chef_version     '>= 14.10'
+version          '1.1.0'
+chef_version     '>= 15.0.293'
 
 supports 'ubuntu', '>= 18.04'
 supports 'debian', '>= 9.8'
 supports 'centos', '>= 7.6'
-
-depends 'tar', '~> 2.2.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,7 @@ vault_addr_option = vault_addr.nil? || vault_addr.empty? ? '' : " -vault-addr #{
 
 command = "#{node['consul_template']['install_dir']}/consul-template -config #{node['consul_template']['config_dir']}" \
           "#{consul_addr_option}#{vault_addr_option} -log-level #{node['consul_template']['log_level']}"
-
+timeout_start = node['consul_template']['service_timeoutstartsec'] ? "TimeoutStartSec=#{node['consul_template']['service_timeoutstartsec']}" : ''
 systemd_unit 'consul-template.service' do
   content <<-EOF
 [Unit]
@@ -82,6 +82,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 User=#{service_user.name}
 Restart=on-failure
 RestartSec=5s
+#{timeout_start}
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,6 @@ RSpec.configure do |c|
   c.formatter = :documentation
   # log level
   c.log_level = :error
+  c.platform = 'centos'
+  c.version = '7.8.2003'
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,42 +1,57 @@
 require 'spec_helper'
 
 describe 'consul-template::default' do
-  let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'centos', version: '7.6').converge('consul-template-cookbook::default')
-  end
-  let(:consul_template_tgz) { "consul-template_#{chef_run.node['consul_template']['version']}_linux_amd64" }
+  context 'default' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new.converge('consul-template-cookbook::default')
+    end
 
-  # Installation
-  it 'symlinks to /usr/local/bin/consul-template' do
-    expect(chef_run).to create_link('/usr/local/bin/consul-template')
-  end
+    # Installation
+    it 'symlinks to /usr/local/bin/consul-template' do
+      expect(chef_run).to create_link('/usr/local/bin/consul-template')
+    end
 
-  # Service
-  it 'should create the consul-template config directory' do
-    expect(chef_run).to create_directory('/etc/consul-template.d')
-  end
+    # Service
+    it 'should create the consul-template config directory' do
+      expect(chef_run).to create_directory('/etc/consul-template.d')
+    end
 
-  it 'should create the consul-template default config' do
-    expect(chef_run).to create_file('/etc/consul-template.d/default.json')
-  end
+    it 'should create the consul-template systemd unit' do
+      expect(chef_run).to create_systemd_unit('consul-template.service')
+    end
 
-  it 'should enable the consul-template service' do
-    expect(chef_run).to enable_service('consul-template')
-  end
+    it 'should start the consul-template service' do
+      expect(chef_run).to start_service('consul-template')
+    end
 
-  it 'should start the consul-template service' do
-    expect(chef_run).to start_service('consul-template')
-  end
+    it 'should create the consul-template service user' do
+      expect(chef_run).to create_user('consul-template')
+      expect(chef_run).to create_group('consul-template')
+    end
 
-  it 'should create the consul-template service user' do
-    expect(chef_run).to create_poise_service_user('consul-template')
-  end
-
-  it 'should enable the consul-template service' do
-    expect(chef_run).to enable_service('consul-template')
+    it 'should enable the consul-template service' do
+      expect(chef_run).to enable_systemd_unit('consul-template.service')
+    end
   end
 
-  it 'should start the consul-template service' do
-    expect(chef_run).to start_service('consul-template')
+  context 'additional settings' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node, _server|
+        node.override['consul_template']['service_execstartpre'] = '/usr/local/bin/wrapper.sh'
+        node.override['consul_template']['vault_addr'] = 'https://my.vault.server:8200'
+      end.converge('consul-template-cookbook::default')
+    end
+
+    it 'should create the consul-template systemd unit with additional settings' do
+      expect(chef_run).to create_systemd_unit('consul-template.service').with_content(
+        %r{ExecStartPre=/usr/local/bin/wrapper.sh}
+      )
+      expect(chef_run).to create_systemd_unit('consul-template.service').with_content(
+        /User=consul-template/
+      )
+      expect(chef_run).to create_systemd_unit('consul-template.service').with_content(
+        %r{ExecStart=/usr/local/bin/consul-template -config /etc/consul-template.d -consul-addr 127.0.0.1:8500 -vault-addr https://my.vault.server:8200 -log-level warn}
+      )
+    end
   end
 end

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'consul_template_config resource' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(step_into: ['consul_template_config'], platform: 'centos', version: '7.6')
+    ChefSpec::SoloRunner.new(step_into: ['consul_template_config'])
                         .converge('test::default')
   end
 


### PR DESCRIPTION
- deprecate the tar_archive resource for archive_file, this requires Chef 15+
- remove the tar cookbook dependency
- add some tests
- update OS used in test frameworks

```
  File /usr/local/bin/consul-template
     ✔  is expected to be file
     ✔  is expected to be executable
  Service consul-template
     ✔  is expected to be enabled
     ✔  is expected to be running
  File /etc/consul-template.d/test
     ✔  is expected to be file
     ✔  content is expected to match "source = \"/tmp/test.config.ctmpl\""
     ✔  content is expected to match "destination = \"/tmp/test.config\""
     ✔  content is expected to match "command = \"touch /tmp/consul-template-command-test\""
  File /tmp/consul-template-command-test
     ✔  is expected to be file

Test Summary: 9 successful, 0 failures, 0 skipped
       Finished verifying <default-centos> (0m8.81s).
-----> Test Kitchen is finished. (0m11.17s)


  File /usr/local/bin/consul-template
     ✔  is expected to be file
     ✔  is expected to be executable
  Service consul-template
     ↺  The `service` resource is not supported on your OS yet.
  File /etc/consul-template.d/test
     ✔  is expected to be file
     ✔  content is expected to match "source = \"/tmp/test.config.ctmpl\""
     ✔  content is expected to match "destination = \"/tmp/test.config\""
     ✔  content is expected to match "command = \"touch /tmp/consul-template-command-test\""
  File /tmp/consul-template-command-test
     ✔  is expected to be file

Test Summary: 7 successful, 0 failures, 1 skipped
       Finished verifying <default-debian> (0m8.31s).
-----> Test Kitchen is finished. (0m10.54s)


  File /usr/local/bin/consul-template
     ✔  is expected to be file
     ✔  is expected to be executable
  Service consul-template
     ✔  is expected to be enabled
     ✔  is expected to be running
  File /etc/consul-template.d/test
     ✔  is expected to be file
     ✔  content is expected to match "source = \"/tmp/test.config.ctmpl\""
     ✔  content is expected to match "destination = \"/tmp/test.config\""
     ✔  content is expected to match "command = \"touch /tmp/consul-template-command-test\""
  File /tmp/consul-template-command-test
     ✔  is expected to be file

Test Summary: 9 successful, 0 failures, 0 skipped
       Finished verifying <default-ubuntu> (0m8.60s).
```

```

consul-template::default
  default
    symlinks to /usr/local/bin/consul-template
    should create the consul-template config directory
    should create the consul-template systemd unit
    should start the consul-template service
    should create the consul-template service user
    should enable the consul-template service
  additional settings
    should create the consul-template systemd unit with additional settings

consul_template_config resource
  create
    should create the consul_template_config
    should create the config file
    should create the ctmplfile
    should add the test key/value
    should notify consul-template to restart

Finished in 5.73 seconds (files took 3.18 seconds to load)
12 examples, 0 failures
```
